### PR TITLE
Sparse dot product

### DIFF
--- a/ikarus/classifier.py
+++ b/ikarus/classifier.py
@@ -114,7 +114,7 @@ def propagate_labels(
         final_pred_proba.loc[certainty_info[f"certain{i}"] == False] = 0.000001
 
         final_step_mtx = connectivities.dot(final_pred_proba.values)
-        final_step_mtx = np.divide(final_step_mtx, final_step_mtx.sum(axis=1))
+        final_step_mtx = np.divide(final_step_mtx, final_step_mtx.sum(axis=0))
         final_pred_proba.loc[:, :] = final_step_mtx
 
         current = final_pred_proba.idxmax(axis=1)

--- a/ikarus/classifier.py
+++ b/ikarus/classifier.py
@@ -82,7 +82,7 @@ def calculate_connectivities(
     path = Path.cwd() / out_dir / name
     path.mkdir(parents=True, exist_ok=True)
     save_npz(path / "connectivities_sparse.npz", sparse)
-    return sparse.todense()
+    return sparse
 
 
 def propagate_labels(
@@ -113,7 +113,7 @@ def propagate_labels(
         ] = True
         final_pred_proba.loc[certainty_info[f"certain{i}"] == False] = 0.000001
 
-        final_step_mtx = np.dot(connectivities, final_pred_proba.values)
+        final_step_mtx = connectivities.dot(final_pred_proba.values)
         final_step_mtx = np.divide(final_step_mtx, final_step_mtx.sum(axis=1))
         final_pred_proba.loc[:, :] = final_step_mtx
 
@@ -393,7 +393,7 @@ class Ikarus:
                 self.out_dir,
             )
         else:
-            connectivities = load_npz(connectivities_path).todense()
+            connectivities = load_npz(connectivities_path)
             if connectivities.shape[0] != adata.shape[0]:
                 raise IndexError(
                     f"Shape of connectivities matrix ({connectivities.shape}) does "
@@ -550,7 +550,7 @@ class Ikarus:
                     self.out_dir,
                 )
             else:
-                connectivities = load_npz(connectivities_path).todense()
+                connectivities = load_npz(connectivities_path)
                 if connectivities.shape[0] != adata.shape[0]:
                     raise IndexError(
                         f"Shape of connectivities matrix ({connectivities.shape}) does "

--- a/ikarus/classifier.py
+++ b/ikarus/classifier.py
@@ -114,7 +114,7 @@ def propagate_labels(
         final_pred_proba.loc[certainty_info[f"certain{i}"] == False] = 0.000001
 
         final_step_mtx = connectivities.dot(final_pred_proba.values)
-        final_step_mtx = np.divide(final_step_mtx, final_step_mtx.sum(axis=0))
+        final_step_mtx = np.divide(final_step_mtx, final_step_mtx.sum(axis=1, keepdims=True))
         final_pred_proba.loc[:, :] = final_step_mtx
 
         current = final_pred_proba.idxmax(axis=1)


### PR DESCRIPTION
When using big datasets, calculation of the dot product with `numpy` requires assigning a lot of virtual memory to the dense connectivity matrix. Most computers won't be able to allocate that much RAM.

Luckily, `scipy` has a sparse matrix dot operation that is both much faster and requires much less RAM. 
It is a method the sparse matrix object. 

Also, we don't have to check if the matrix is sparse because `numpy` has an inner method for dense matrices that is called in the same way.